### PR TITLE
feat: include --profile argument to apply a lxd profile during instance creation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,59 @@
-__pycache__/
+# Byte-compiled / optimized / DLL files
+*.py[cod]
+*.$py.class
+
+# Distribution / packaging
+.Python
+build/
 dist/
+eggs/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Virtual environment
+venv/
+env/
+ENV/
+*.env
+
+# VSCode settings
+.vscode/
+
+# PyCharm settings
+.idea/
+
+# Test coverage reports
+.coverage
+coverage.xml
+nosetests.xml
+pytest-debug.log
+*.cover
+
+# MyPy
+.mypy_cache/
+
+# PyInstaller
+*.spec
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# Sphinx documentation
+docs/_build/
+build/
+temp/
+
+# Cython debug symbols
+cython_debug/
+
+# JetBrains IDEs
+.idea/
+
+# Local configurations
+*.local
+*.config


### PR DESCRIPTION
I also added a boilerplate `.gitignore` for Python projects. Might be overkill.

I tested this from a `landscape-server` repo directory, so that I could get "real-ish" results.

```sh
python3 -m venv venv
source venv/bin/activate
pip install -e /path/to/this/branch
```

I have `dev_lxc` installed locally too, so the version on this branch would get shadowed. I just referenced it directly in the venv.

```
venv/bin/dev_lxc create --help
venv/bin/dev_lxc create jammy -p landscape-server-dev -c dev/dev-lxc-config-jammy.yaml
venv/bin/dev_lxc shell jammy
```

Confirm that the profile has been applied. Some other interesting cases:
- Applying a nonexistent profile errors quickly, when the instance is created.
- Applying a profile but not config works fine
- Applying config but not a profile works fine