### PR TITLE
feat: add support for multiple containers of the same series in a directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,15 @@ Create an instance using a specific Ubuntu series, by codename:
 
     dev_lxc create jammy
 
-The instance name is generated from the current directory, so you can only have one instance of each series per directory. Names _will_ clash.
+Instance names are generated from the current directory + the series of the container; for example: `myProject-noble`. If you create another container of the same series in the same directory (or one with the same directory name elsewhere in your filesystem), a hex-character suffix will be added to the instance name to ensure uniqueness; for example: `myProject-noble-e8d`.
 
 If you have a valid YAML file for configuring the instance (nice for if you want it to start with certain packages installed):
 
     dev_lxc create jammy --config ./my-config.yaml
+
+### Interacting with existing instances
+
+Use the commands below to interact with your existing instances. If there is only a partial match or if there are multiple matches for your current directory + series, you will be prompted to specify which instance to act upon. At this time, running these commands while specifying an instance name instead of its series is not supported.
 
 ### Open a shell in an instance
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Create an instance using a specific Ubuntu series, by codename:
 
     dev_lxc create jammy
 
-Instance names are generated from the current directory + the series of the container; for example: `myProject-noble`. If you create another container of the same series in the same directory (or one with the same directory name elsewhere in your filesystem), a hex-character suffix will be added to the instance name to ensure uniqueness; for example: `myProject-noble-e8d`.
+You can create multiple instances of the same series in the same directory.
 
 If you have a valid YAML file for configuring the instance (nice for if you want it to start with certain packages installed):
 
@@ -22,7 +22,7 @@ If you have a valid YAML file for configuring the instance (nice for if you want
 
 ### Interacting with existing instances
 
-Use the commands below to interact with your existing instances. If there is only a partial match or if there are multiple matches for your current directory + series, you will be prompted to specify which instance to act upon. At this time, running these commands while specifying an instance name instead of its series is not supported.
+Use the commands below to interact with your existing instances. You may be prompted to specify which instance to act upon if there are multiple or partial matches for the series you specify.
 
 ### Open a shell in an instance
 

--- a/dev_lxc/cmd.py
+++ b/dev_lxc/cmd.py
@@ -359,22 +359,16 @@ def _fetch_instance_name(series: str) -> str:
     multiple extant instances, and returns a single instance_name
     """
     # no accomodation yet for user to enter exact container name instead of just series
-    proj_dir = os.path.basename(os.getcwd())
-    instance_name = f"{proj_dir}-{series}"
+    instance_name = _create_default_instance_name(series)
     matches = _get_instance_name_matches(instance_name)
     if not matches:
-        raise Exception(f"Error: no instance found with the name {instance_name}")
-        # I suppose we'll have to catch this everywhere _fetch_instance_name is called
+        return ""
+        # calling function needs to handle empty string result (no matches)
     elif len(matches) == 1 and str(matches[0]) == instance_name:
         return instance_name
     else:
-        try:
-            instance_name = _get_instance_name_input(instance_name, matches)
-            return instance_name
-        except Exception:
-            # I don't feel great about this
-            print("No instance selected - stopping command execution")
-            raise
+        instance_name = _get_instance_name_input(instance_name, matches)
+        return instance_name
 
 
 def _create_instance_name(series: str) -> str:
@@ -420,22 +414,23 @@ def _create_variant_instance_name(instance_name: str) -> str:
 
 def _get_instance_name_input(instance_name: str, matches: list) -> str:
     """When multiple instances match {instance_name}, allows user to specify instance to act upon"""
-    prompt = "Enter the index of the instance you would like to act upon: "
-
     if len(matches) == 1:
-        print(f"One partial match for {instance_name}:\n-----\nmatches[0]")
-        choice = _get_confirmation("Interact with this instance? [Y/n]: ")
+        print(f"One partial match for {instance_name}:\n-----\n")
+        choice = _get_confirmation(f"Interact with instance {matches[0]}? [Y/n]: ")
         if choice:
             instance_name = str(matches[0])
         else:
-            raise Exception
+            return ""
+            # calling function needs to handle empty string return
     else:
         print(f"Multiple existing instances match the name '{instance_name}':\n-----")
         for index, match in enumerate(matches):
             print(f"[{index}]\t{match}")
 
         while True:
-            choice = input(prompt)
+            choice = input(
+                "Enter the index of the instance you would like to act upon: "
+            )
             try:
                 instance_index = int(choice)
                 if 0 < instance_index < len(matches):

--- a/dev_lxc/cmd.py
+++ b/dev_lxc/cmd.py
@@ -390,12 +390,13 @@ def _create_variant_instance_name(instance_name: str) -> str:
     return variant_name
 
 
-def _get_instance_name():
+def _fetch_instance_name():
     pass
-    # thinking of building this helper to save space in main cmds functions
+    # thinking of building this helper to save space in main cmds functions;
     # like, create(), shell(), etc. will call this, which will in turn check
     # for existing names, maybe create a variant, look for matches, etc;
-    # still to be planned in more detail
+    # still to be planned in more detail (obviously)
+    # main issue - can this handle both create() and non-create() functions?
 
 
 def _get_instance_name_input(instance_name: str, matches: list) -> str:

--- a/dev_lxc/cmd.py
+++ b/dev_lxc/cmd.py
@@ -412,12 +412,9 @@ def _create_default_instance_name(series: str) -> str:
 
 def _create_variant_instance_name(instance_name: str) -> str:
     """Accepts instance name and returns a variant name to avoid naming collisions"""
-    variant_name = (
-        f"{instance_name}-{''.join(random.choices(string.ascii_lowercase, k=3))}"
-    )
-    # there is a risk of bad words accidentally showing up here... ignoring for now
+    variant_name = f"{instance_name}-{''.join(random.choices(string.hexdigits, k=3))}"
     while _get_instance_name_matches(variant_name) != []:
-        variant_name += "".join(random.choices(string.ascii_lowercase, k=1))
+        variant_name += "".join(random.choices(string.hexdigits, k=1))
     return variant_name
 
 
@@ -426,8 +423,7 @@ def _get_instance_name_input(instance_name: str, matches: list) -> str:
     prompt = "Enter the index of the instance you would like to act upon: "
 
     if len(matches) == 1:
-        print(f"One partial match for {instance_name}:\n-----")
-        print(matches[0])
+        print(f"One partial match for {instance_name}:\n-----\nmatches[0]")
         choice = _get_confirmation("Interact with this instance? [Y/n]: ")
         if choice:
             instance_name = str(matches[0])

--- a/dev_lxc/cmd.py
+++ b/dev_lxc/cmd.py
@@ -411,7 +411,7 @@ def _create_variant_instance_name(instance_name: str) -> str:
 def _get_instance_name_input(instance_name: str, matches: list) -> str:
     """When multiple instances match {instance_name}, allows user to specify instance to act upon"""
     if len(matches) == 1:
-        print(f"One partial match for {instance_name}:\n-----\n")
+        print(f"One partial match for {instance_name};\n")
         choice = _get_confirmation(f"Interact with instance {matches[0]}? [Y/n]: ")
         if choice:
             instance_name = str(matches[0])
@@ -429,7 +429,7 @@ def _get_instance_name_input(instance_name: str, matches: list) -> str:
             )
             try:
                 instance_index = int(choice)
-                if 0 < instance_index < len(matches):
+                if 0 <= instance_index < len(matches):
                     break
                 else:
                     print(f"Error: Index must be between 0 and {len(matches) - 1}")

--- a/dev_lxc/cmd.py
+++ b/dev_lxc/cmd.py
@@ -23,8 +23,7 @@ DEFAULT_CONFIG = os.path.expanduser("~/" + CONFIG_DOTDIR)
 
 # revert to original `create` pending helper function decisions
 def create(series: str, config: str = "", profile: str = ""):
-    proj_dir = os.path.basename(os.getcwd())
-    instance_name = os.path.basename(proj_dir) + f"-{series}"
+    instance_name = _create_instance_name(series)
 
     if config:
         print("Using config " + config)
@@ -44,7 +43,7 @@ Jump into your new instance with:
 def shell(series: str, stop_after: bool):
     proj_dir = os.path.basename(os.getcwd())
     lxc_repo_path = f"/home/ubuntu/{os.path.basename(proj_dir)}"
-    instance_name = os.path.basename(proj_dir) + f"-{series}"
+    instance_name = _fetch_instance_name(series)
 
     _start_if_stopped(instance_name)
 
@@ -65,12 +64,11 @@ def shell(series: str, stop_after: bool):
 
     if stop_after:
         print(f"Stopping {instance_name}")
-        stop(series)
+        stop(instance_name)
 
 
 def remove(series: str):
-    proj_dir = os.path.basename(os.getcwd())
-    instance_name = os.path.basename(proj_dir) + f"-{series}"
+    instance_name = _fetch_instance_name(series)
 
     _remove(instance_name)
 
@@ -81,10 +79,10 @@ def exec_cmd(series: str, command: str, stop_after: bool, emphemeral: bool, *env
 
     if emphemeral:
         ident = "".join(random.sample(string.ascii_lowercase, 12))
-        instance_name = os.path.basename(proj_dir) + f"-{series}-{ident}"
+        instance_name = f"-{_fetch_instance_name(series)}-{ident}"
         _create_container(instance_name, series)
     else:
-        instance_name = os.path.basename(proj_dir) + f"-{series}"
+        instance_name = _fetch_instance_name(series)
 
     _start_if_stopped(instance_name)
 
@@ -130,15 +128,13 @@ def exec_cmd(series: str, command: str, stop_after: bool, emphemeral: bool, *env
 
 
 def start(series: str) -> None:
-    proj_dir = os.path.basename(os.getcwd())
-    instance_name = os.path.basename(proj_dir) + f"-{series}"
+    instance_name = _fetch_instance_name(series)
 
     _start_if_stopped(instance_name)
 
 
 def stop(series: str) -> None:
-    proj_dir = os.path.basename(os.getcwd())
-    instance_name = os.path.basename(proj_dir) + f"-{series}"
+    instance_name = _fetch_instance_name(series)
 
     _stop(instance_name)
 

--- a/dev_lxc/cmd.py
+++ b/dev_lxc/cmd.py
@@ -415,7 +415,7 @@ def _create_variant_instance_name(instance_name: str) -> str:
     variant_name = (
         f"{instance_name}-{''.join(random.choices(string.ascii_lowercase, k=3))}"
     )
-    # there is a risk of a few bad three-letter words accidentally showing up here...
+    # there is a risk of bad words accidentally showing up here... ignoring for now
     while _get_instance_name_matches(variant_name) != []:
         variant_name += "".join(random.choices(string.ascii_lowercase, k=1))
     return variant_name

--- a/dev_lxc/cmd.py
+++ b/dev_lxc/cmd.py
@@ -21,7 +21,6 @@ CONFIG_DOTDIR = ".dev-lxc"
 DEFAULT_CONFIG = os.path.expanduser("~/" + CONFIG_DOTDIR)
 
 
-# revert to original `create` pending helper function decisions
 def create(series: str, config: str = "", profile: str = ""):
     instance_name = _create_instance_name(series)
 

--- a/dev_lxc/cmd.py
+++ b/dev_lxc/cmd.py
@@ -417,9 +417,7 @@ def _create_variant_instance_name(instance_name: str) -> str:
     )
     # there is a risk of a few bad three-letter words accidentally showing up here...
     while _get_instance_name_matches(variant_name) != []:
-        variant_name = variant_name + "".join(
-            random.choices(string.ascii_lowercase, k=1)
-        )
+        variant_name += "".join(random.choices(string.ascii_lowercase, k=1))
     return variant_name
 
 

--- a/dev_lxc/cmd.py
+++ b/dev_lxc/cmd.py
@@ -352,14 +352,13 @@ def _fetch_instance_name(series: str) -> str:
     """
     Accepts a series name from calling function, searches for extant instance
     by the name "proj_dir + series", resolves case where instance name matches with
-    multiple extant instances, and returns a single instance_name
+    multiple extant instances, and returns a single instance_name; may return
+    "" if no match found or user declines input in _get_instance_name_input
     """
-    # no accomodation yet for user to enter exact container name instead of just series
     instance_name = _create_default_instance_name(series)
     matches = _get_instance_name_matches(instance_name)
     if not matches:
         return ""
-        # calling function needs to handle empty string result (no matches)
     elif len(matches) == 1 and str(matches[0]) == instance_name:
         return instance_name
     else:
@@ -402,9 +401,11 @@ def _create_default_instance_name(series: str) -> str:
 
 def _create_variant_instance_name(instance_name: str) -> str:
     """Accepts instance name and returns a variant name to avoid naming collisions"""
-    variant_name = f"{instance_name}-{''.join(random.choices(string.hexdigits, k=3))}"
+    variant_name = (
+        f"{instance_name}-{''.join(random.choices(string.hexdigits, k=3)).lower()}"
+    )
     while _get_instance_name_matches(variant_name) != []:
-        variant_name += "".join(random.choices(string.hexdigits, k=1))
+        variant_name += "".join(random.choices(string.hexdigits, k=1)).lower()
     return variant_name
 
 
@@ -417,7 +418,6 @@ def _get_instance_name_input(instance_name: str, matches: list) -> str:
             instance_name = str(matches[0])
         else:
             return ""
-            # calling function needs to handle empty string return
     else:
         print(f"Multiple existing instances match the name '{instance_name}':\n-----")
         for index, match in enumerate(matches):

--- a/dev_lxc/cmd.py
+++ b/dev_lxc/cmd.py
@@ -82,7 +82,7 @@ def exec_cmd(series: str, command: str, stop_after: bool, emphemeral: bool, *env
 
     if emphemeral:
         ident = "".join(random.sample(string.ascii_lowercase, 12))
-        instance_name = f"-{_create_instance_name(series)}-{ident}"
+        instance_name = f"{_create_instance_name(series)}-{ident}"
         _create_container(instance_name, series)
     else:
         instance_name = _fetch_instance_name(series)

--- a/dev_lxc/cmd.py
+++ b/dev_lxc/cmd.py
@@ -116,10 +116,7 @@ def exec_cmd(series: str, command: str, stop_after: bool, emphemeral: bool, *env
     result = subprocess.run(run_args)
 
     if result.returncode:
-        print(
-            f"Error running command {command} on instance {instance_name}",
-            file=sys.stderr,
-        )
+        print(f"Error running command {command} on instance {instance_name}", file=sys.stderr)
     else:
         print("Command execution completed successfully")
 
@@ -164,8 +161,7 @@ def _discover_config(series: str) -> str:
     home_dir = os.path.expanduser("~")
 
     paths_to_check = (
-        os.path.join(*parts)
-        for parts in (
+        os.path.join(*parts) for parts in (
             (CONFIG_DOTDIR, series_yaml),
             (CONFIG_DOTDIR, "base.yaml"),
             (home_dir, CONFIG_DOTDIR, series_yaml),
@@ -202,10 +198,7 @@ def _exec_config(series: str, config: str = "") -> None:
     dev_lxc_exec = config_dict["dev-lxc-exec"]
 
     if not isinstance(dev_lxc_exec, (str, list)):
-        print(
-            f"ERROR: dev-lxc-exec in {config} must be either a string or list of strings",
-            file=sys.stderr,
-        )
+        print(f"ERROR: dev-lxc-exec in {config} must be either a string or list of strings", file=sys.stderr)
         return
 
     if isinstance(dev_lxc_exec, str):
@@ -576,11 +569,7 @@ def main():
     elif hasattr(parsed, "stop_after"):
         parsed.func(parsed.series, parsed.stop_after)
     elif hasattr(parsed, "config"):
-        parsed.func(
-            parsed.series,
-            parsed.config or _discover_config(parsed.series),
-            parsed.profile,
-        )
+        parsed.func(parsed.series, parsed.config or _discover_config(parsed.series), parsed.profile)
     else:
         parsed.func(parsed.series)
 

--- a/dev_lxc/cmd.py
+++ b/dev_lxc/cmd.py
@@ -422,8 +422,8 @@ def _create_variant_instance_name(instance_name: str) -> str:
 def _get_instance_name_input(instance_name: str, matches: list) -> str:
     """When multiple instances match {instance_name}, allows user to specify instance to act upon"""
     if len(matches) == 1:
-        print(f"One partial match for {instance_name};\n")
-        choice = _get_confirmation(f"Interact with instance {matches[0]}? [Y/n]: ")
+        print(f"One partial match for {instance_name}: '{matches[0]}'")
+        choice = _get_confirmation(f"Interact with instance '{matches[0]}'? [Y/n]: ")
         if choice:
             instance_name = str(matches[0])
         else:

--- a/dev_lxc/cmd.py
+++ b/dev_lxc/cmd.py
@@ -365,20 +365,36 @@ def _check_name_exists(instance_name: str) -> tuple[bool, list[str]]:
         return False, []
 
 
-def _construct_instance_name(series: str) -> str:
+def _construct_instance_name(series: str) -> tuple[str, str]:
     """
     Creates instance_name variable, but checks whether instance name is unique
-    If not, allows user to specify which instance to act upon
+    If not, generates an alternate_name that other functions may/may not choose to use
     """
     proj_dir = os.path.basename(os.getcwd())
     instance_name = proj_dir + f"-{series}"  # slight mod to logic elsewhere
     exists, matches = _check_name_exists(instance_name)
 
+    if exists:
+        alternate_name = ""
+        for num in range(2, 100):
+            alternate_name = instance_name + f"-{num}"
+            exists, _ = _check_name_exists(alternate_name)
+            if not exists:
+                break
+        return instance_name, alternate_name
+    else:
+        return instance_name, ""
+
+
+"""
+WIP - will return later - copy/pasta mess
+def _get_instance_name_input(instance_name: str) -> str:
     if exists and len(matches) > 1:
         # implement logic to modify auto-name
         print("Multiple instances in this directory match that instance name")
         for index, match in matches:
             print(f"[{index}]\t{match}")
+        print("Which instance would you like")
         choice = input("Which instance would you like to act upon? [num]: ")
         while type(choice) is not int or choice < 0 or choice >= len(matches):
             choice = input("Please enter a number from the instance list. [num]: ")
@@ -387,6 +403,7 @@ def _construct_instance_name(series: str) -> str:
 
     else:
         return instance_name
+"""
 
 
 def main():

--- a/dev_lxc/cmd.py
+++ b/dev_lxc/cmd.py
@@ -239,9 +239,7 @@ def _create_container(
             with open(config, "rb") as config_fp:
                 config_input = config_fp.read()
         except OSError as e:
-            print(
-                f"ERROR: Could not read LXD config from {config}: {e}", file=sys.stderr
-            )
+            print(f"ERROR: Could not read LXD config from {config}: {e}", file=sys.stderr)
             config_input = None
     else:
         config_input = None

--- a/dev_lxc/cmd.py
+++ b/dev_lxc/cmd.py
@@ -22,8 +22,12 @@ DEFAULT_CONFIG = os.path.expanduser("~/" + CONFIG_DOTDIR)
 
 
 def create(series: str, config: str = "", profile: str = ""):
-    proj_dir = os.path.basename(os.getcwd())
-    instance_name = os.path.basename(proj_dir) + f"-{series}"
+    instance_name, alternate_name = _construct_instance_name(series)
+
+    if alternate_name:
+        print(f"Multiple instances already exist with the name {instance_name}")
+        print(f"An alternate instance name of {alternate_name} will be used instead.")
+        instance_name = alternate_name
 
     if config:
         print("Using config " + config)
@@ -383,27 +387,26 @@ def _construct_instance_name(series: str) -> tuple[str, str]:
                 break
         return instance_name, alternate_name
     else:
-        return instance_name, ""
+        return instance_name, None  # <- is none type okay to return here?
 
 
-"""
-WIP - will return later - copy/pasta mess
-def _get_instance_name_input(instance_name: str) -> str:
-    if exists and len(matches) > 1:
-        # implement logic to modify auto-name
-        print("Multiple instances in this directory match that instance name")
-        for index, match in matches:
-            print(f"[{index}]\t{match}")
-        print("Which instance would you like")
-        choice = input("Which instance would you like to act upon? [num]: ")
-        while type(choice) is not int or choice < 0 or choice >= len(matches):
-            choice = input("Please enter a number from the instance list. [num]: ")
-        instance_name = matches[choice]
-        return instance_name
+def _get_instance_name_input(instance_name: str, matches: list) -> str:
+    """Allows user to choose instance upon name collision"""
+    prompt = "Enter the index of the instance you would like to act upon: "
 
-    else:
-        return instance_name
-"""
+    print("Multiple instance names match that cwd and series combination:")
+    for index, match in matches:
+        print(f"[{index}]\t{match}")
+    instance_index = input(prompt)
+    while (
+        instance_index is not int
+        or instance_index < 0
+        or instance_index >= len(matches)
+    ):
+        instance_index = input(f"Invalid entry - {prompt}")
+
+    instance_name = matches[instance_index]
+    return instance_name
 
 
 def main():

--- a/dev_lxc/cmd.py
+++ b/dev_lxc/cmd.py
@@ -116,7 +116,10 @@ def exec_cmd(series: str, command: str, stop_after: bool, emphemeral: bool, *env
     result = subprocess.run(run_args)
 
     if result.returncode:
-        print(f"Error running command {command} on instance {instance_name}", file=sys.stderr)
+        print(
+            f"Error running command {command} on instance {instance_name}",
+            file=sys.stderr,
+        )
     else:
         print("Command execution completed successfully")
 
@@ -161,7 +164,8 @@ def _discover_config(series: str) -> str:
     home_dir = os.path.expanduser("~")
 
     paths_to_check = (
-        os.path.join(*parts) for parts in (
+        os.path.join(*parts)
+        for parts in (
             (CONFIG_DOTDIR, series_yaml),
             (CONFIG_DOTDIR, "base.yaml"),
             (home_dir, CONFIG_DOTDIR, series_yaml),
@@ -198,7 +202,10 @@ def _exec_config(series: str, config: str = "") -> None:
     dev_lxc_exec = config_dict["dev-lxc-exec"]
 
     if not isinstance(dev_lxc_exec, (str, list)):
-        print(f"ERROR: dev-lxc-exec in {config} must be either a string or list of strings", file=sys.stderr)
+        print(
+            f"ERROR: dev-lxc-exec in {config} must be either a string or list of strings",
+            file=sys.stderr,
+        )
         return
 
     if isinstance(dev_lxc_exec, str):
@@ -239,7 +246,9 @@ def _create_container(
             with open(config, "rb") as config_fp:
                 config_input = config_fp.read()
         except OSError as e:
-            print(f"ERROR: Could not read LXD config from {config}: {e}", file=sys.stderr)
+            print(
+                f"ERROR: Could not read LXD config from {config}: {e}", file=sys.stderr
+            )
             config_input = None
     else:
         config_input = None
@@ -406,7 +415,10 @@ def _get_instance_name_input(instance_name: str, matches: list) -> str:
     """When multiple instances match {instance_name}, allows user to specify instance to act upon"""
     if len(matches) == 1:
         print(f"One partial match for {instance_name}: '{matches[0]}'")
-        choice = _get_confirmation(f"Interact with instance '{matches[0]}'? [Y/n]: ")
+        choice = _get_confirmation(
+            f"Interact with instance '{matches[0]}'? [Y/n]: ",
+            True,
+        )
         if choice:
             instance_name = str(matches[0])
         else:
@@ -438,20 +450,20 @@ def _get_instance_name_input(instance_name: str, matches: list) -> str:
     return instance_name
 
 
-def _get_confirmation(prompt: str) -> bool:
+def _get_confirmation(prompt: str = "Proceed?", default: bool = True) -> bool:
     """
-    Use {prompt} to get confirmation from user on whether to proceed or not; default is True (proceed)
+    Use {prompt} to get confirmation from user on whether to proceed or not; default configurable
     """
     while True:
         choice = input(prompt).strip().lower()
         if choice == "":
-            return True
+            return default
         if choice in ("y", "yes"):
             return True
         elif choice in ("n", "no"):
             return False
         else:
-            print("Invalid entry - please enter 'y' or 'n'")
+            print("Invalid entry - please enter 'y'/'yes' or 'n'/'no'")
 
 
 def main():
@@ -558,7 +570,11 @@ def main():
     elif hasattr(parsed, "stop_after"):
         parsed.func(parsed.series, parsed.stop_after)
     elif hasattr(parsed, "config"):
-        parsed.func(parsed.series, parsed.config or _discover_config(parsed.series), parsed.profile)
+        parsed.func(
+            parsed.series,
+            parsed.config or _discover_config(parsed.series),
+            parsed.profile,
+        )
     else:
         parsed.func(parsed.series)
 

--- a/dev_lxc/cmd.py
+++ b/dev_lxc/cmd.py
@@ -349,12 +349,7 @@ def _stop(instance_name: str) -> None:
 
 
 def _fetch_instance_name(series: str) -> str:
-    """
-    Accepts a series name from calling function, searches for extant instance
-    by the name "proj_dir + series", resolves case where instance name matches with
-    multiple extant instances, and returns a single instance_name; may return
-    "" if no match found or user declines input in _get_instance_name_input
-    """
+    """Returns instance_name of given series in cwd, or "" if none found or user declines selection"""
     instance_name = _create_default_instance_name(series)
     matches = _get_instance_name_matches(instance_name)
     if not matches:
@@ -368,10 +363,7 @@ def _fetch_instance_name(series: str) -> str:
 
 
 def _create_instance_name(series: str) -> str:
-    """
-    Accept series string name from calling function, and return a new instance name that does
-    not conflict with any existing instance names
-    """
+    """Creates new, unique instance_name and returns it"""
     instance_name = _create_default_instance_name(series)
     if _get_instance_name_matches(instance_name):
         return _create_variant_instance_name(instance_name)
@@ -380,7 +372,7 @@ def _create_instance_name(series: str) -> str:
 
 
 def _get_instance_name_matches(instance_name: str) -> list[str]:
-    """Accepts an instance name and returns list of instances whose names include {instance_name}"""
+    """Returns list of instances whose names include {instance_name}, or empty list if no matches found"""
     matches = subprocess.run(
         ["lxc", "ls", "--all-projects", "-c", "n", "-f", "csv", instance_name],
         # `lxc ls` command note:
@@ -394,14 +386,14 @@ def _get_instance_name_matches(instance_name: str) -> list[str]:
 
 
 def _create_default_instance_name(series: str) -> str:
-    """Returns instance_name string, constructed from project directory and instance series"""
+    """Returns instance_name string composed of cwd and series"""
     proj_dir = os.path.basename(os.getcwd())
     instance_name = f"{proj_dir}-{series}"
     return instance_name
 
 
 def _create_variant_instance_name(instance_name: str) -> str:
-    """Accepts instance name and returns a variant name to avoid naming collisions"""
+    """Appends random hex digits to instance name to avoid instance naming collisions"""
     variant_name = (
         f"{instance_name}-{''.join(random.choices(string.hexdigits, k=3)).lower()}"
     )
@@ -448,8 +440,7 @@ def _get_instance_name_input(instance_name: str, matches: list) -> str:
 
 def _get_confirmation(prompt: str) -> bool:
     """
-    Accept a prompt from a function needing user confirmation and return a bool
-    representing the user's choice to proceed (True) or not (False); default is True
+    Use {prompt} to get confirmation from user on whether to proceed or not; default is True (proceed)
     """
     while True:
         choice = input(prompt).strip().lower()

--- a/dev_lxc/cmd.py
+++ b/dev_lxc/cmd.py
@@ -452,13 +452,13 @@ def _get_instance_name_input(instance_name: str, matches: list) -> str:
 
 def _get_confirmation(prompt: str = "Proceed?", default: bool = True) -> bool:
     """
-    Use {prompt} to get confirmation from user on whether to proceed or not; default configurable
+    Use {prompt} to get confirmation from user on whether to proceed or not; default is configurable
     """
     while True:
         choice = input(prompt).strip().lower()
         if choice == "":
             return default
-        if choice in ("y", "yes"):
+        elif choice in ("y", "yes"):
             return True
         elif choice in ("n", "no"):
             return False


### PR DESCRIPTION
## purpose

This proposal adds functions to allow creating and interacting with multiple containers of the same series within a given directory.  

Currently, only one instance of a given series can exist based on a directory name.  For example:

1. `myProject-noble` already exists, based on `/home/user/myProject/`; creating another noble instance from that directory is not currently possible
2. `myProject-noble` already exists, based on `/home/user/myProject/`; creating another noble instance from the directory `/home/user/sideProjects/myProject/` is also not possible

The changes in this PR do two things, broadly:

- create a series of internal helper functions to support cases where instance names collide, resolving the collision by appending characters to the instance name and/or seeking input from the user for disambiguation
- modify the existing public and private functions to call the new private function set when dealing with `instance_name`s

## new functions:

- `_fetch_instance_name`: accept a series from a calling function and return a matching, existing lxd container name; seek user input if needed to decide between multiple matching instance names
- `_create_instance_name`: accept a series from a calling function and construct a name by one of two ways: 1) if no matching instance already exists, return default name `cwd+series`, 2) if matches are found, return alternate new name `cwd+series+hex_chars`
- `_create_default_instance_name`: helper for `_create_instance_name` option 1 above
- `_create_variant_instance_name`: helper for `_create_instance_name` option 2 above
- `_get_instance_name_input`: function to seek user decision when multiple matches or a single partial match are found for user command
- `_get_confirmation`: helper for `_get_instance_name_input` (and potentially other future functions) to define user input defaults when they are asked to specify instance to act upon

## manual testing

### create instance

```
    ➜  dev-lxc git:(name-collisions) python3 dev_lxc/cmd.py create noble
    Launching dev-lxc-noble
    Waiting for dev-lxc-noble to complete initialization and package installation (this might take a while)
    .......................status: done
    Device dev-lxc-noble-src added to dev-lxc-noble
    All done! ✨ 🍰 ✨

    Jump into your new instance with:
        dev_lxc shell noble
```

### create another noble instance

```
    ➜  dev-lxc git:(name-collisions) python3 dev_lxc/cmd.py create noble
    Launching dev-lxc-noble-bda
    Waiting for dev-lxc-noble-bda to complete initialization and package installation (this might take a while)
    ..............status: done
    Device dev-lxc-noble-bda-src added to dev-lxc-noble-bda
    All done! ✨ 🍰 ✨

    Jump into your new instance with:
        dev_lxc shell noble
```

### verify two running instances

```
    ➜  dev-lxc git:(name-collisions) lxc ls -c ns
    +-------------------+---------+
    |       NAME        |  STATE  |
    +-------------------+---------+
    | dev-lxc-noble     | RUNNING |
    +-------------------+---------+
    | dev-lxc-noble-bda | RUNNING |
    +-------------------+---------+
```

### interact with instance

```
    ➜  dev-lxc git:(name-collisions) python3 dev_lxc/cmd.py shell noble
    Multiple existing instances match the name 'dev-lxc-noble':
    -----
    [0]     dev-lxc-noble
    [1]     dev-lxc-noble-bda
    Enter the index of the instance you would like to act upon, or -1 for none: 0
    To run a command as administrator (user "root"), use "sudo <command>".
    See "man sudo_root" for details.

    ubuntu@dev-lxc-noble:~/dev-lxc$
```

### decline interaction

```
    ➜  dev-lxc git:(name-collisions) python3 dev_lxc/cmd.py shell noble
    Multiple existing instances match the name 'dev-lxc-noble':
    -----
    [0]     dev-lxc-noble
    [1]     dev-lxc-noble-bda
    Enter the index of the instance you would like to act upon, or -1 for none: -1
    User declined instance interaction - exiting
```

### interact with partial match instance

```
    ➜  dev-lxc git:(name-collisions) python3 dev_lxc/cmd.py remove noble
    Multiple existing instances match the name 'dev-lxc-noble':
    -----
    [0]     dev-lxc-noble
    [1]     dev-lxc-noble-bda
    Enter the index of the instance you would like to act upon, or -1 for none: 0
    Removed instance dev-lxc-noble
    ➜  dev-lxc git:(name-collisions) python3 dev_lxc/cmd.py shell noble
    One partial match for dev-lxc-noble: 'dev-lxc-noble-bda'
    Interact with instance 'dev-lxc-noble-bda'? [Y/n]: Y
    To run a command as administrator (user "root"), use "sudo <command>".
    See "man sudo_root" for details.

    ubuntu@dev-lxc-noble-bda:~/dev-lxc$
```

### decline partial match interaction

```
    ➜  dev-lxc git:(name-collisions) python3 dev_lxc/cmd.py shell noble
    One partial match for dev-lxc-noble: 'dev-lxc-noble-bda'
    Interact with instance 'dev-lxc-noble-bda'? [Y/n]: n
    User declined to interaction with dev-lxc-noble-bda - exiting
```

### exec to ephemeral instance

```
    ➜  dev-lxc git:(name-collisions) python3 dev_lxc/cmd.py exec --ephemeral --stop-after noble pwd
    Launching dev-lxc-noble-cef-yidtfnqxacbz
    Waiting for dev-lxc-noble-cef-yidtfnqxacbz to complete initialization and package installation (this might take a while)
    ............status: done
    Device dev-lxc-noble-cef-yidtfnqxacbz-src added to dev-lxc-noble-cef-yidtfnqxacbz
    /home/ubuntu/dev-lxc
    Command execution completed successfully
    Stopping dev-lxc-noble-cef-yidtfnqxacbz
    Removing dev-lxc-noble-cef-yidtfnqxacbz
    Removed instance dev-lxc-noble-cef-yidtfnqxacbz
    ➜  dev-lxc git:(name-collisions) lxc ls -c ns
    +-------------------+---------+
    |       NAME        |  STATE  |
    +-------------------+---------+
    | dev-lxc-noble-bda | RUNNING |
    +-------------------+---------+
```